### PR TITLE
First simulation roundtrip test

### DIFF
--- a/source/BaselineOfPharoDEVS/BaselineOfPharoDEVS.class.st
+++ b/source/BaselineOfPharoDEVS/BaselineOfPharoDEVS.class.st
@@ -15,10 +15,11 @@ BaselineOfPharoDEVS >> baseline: spec [
 				package: 'DEVS-Core';
 				package: 'DEVS-Core-Tests' with: [ spec requires: #('DEVS-Core') ];
 				package: 'DEVS-Examples' with: [ spec requires: #('DEVS-Core') ];
-				package: 'DEVS-Models' with: [ spec requires: #('DEVS-Core') ].
+				package: 'DEVS-Models' with: [ spec requires: #('DEVS-Core') ];
+				package: 'DEVS-Models-Tests' with: [ spec requires: #('DEVS-Models') ].
 				
 			spec 
 				group: 'default' with: #('Core' 'Models');
 				group: 'Core' with: #('DEVS-Core' 'DEVS-Core-Tests' );
-				group: 'Models' with: #('DEVS-Models')]
+				group: 'Models' with: #('DEVS-Models' 'DEVS-Models-Tests') ]
 ]

--- a/source/DEVS-Core/DEVSCoupledComponent.class.st
+++ b/source/DEVS-Core/DEVSCoupledComponent.class.st
@@ -15,6 +15,11 @@ DEVSCoupledComponent class >> displayLabel [
 	^ #coupled
 ]
 
+{ #category : 'arithmetic' }
+DEVSCoupledComponent >> / aString [ 
+	^ self componentNamed: aString 
+]
+
 { #category : 'modeling2' }
 DEVSCoupledComponent >> addComponent: aComponent [ 
 	components 

--- a/source/DEVS-Core/DEVSLogger.class.st
+++ b/source/DEVS-Core/DEVSLogger.class.st
@@ -33,7 +33,7 @@ DEVSLogger >> inspectionEvents [
 		addColumn: (SpStringTableColumn new title: 'event'; width: 80; evaluated: [:each | each class displayLabel ]);
 		addColumn: (SpStringTableColumn new
 			title: 'component';
-			evaluated: [:each | each component path ]);
+			evaluated: [:each | each component ]);
 		addColumn: (SpStringTableColumn new
 			title: 'description';
 			evaluated: [:each | each payload ])

--- a/source/DEVS-Core/DEVSSimulation.class.st
+++ b/source/DEVS-Core/DEVSSimulation.class.st
@@ -11,6 +11,11 @@ Class {
 	#tag : 'Basic'
 }
 
+{ #category : 'arithmetic' }
+DEVSSimulation >> / aString [ 
+	^ model / aString 
+]
+
 { #category : 'accessing' }
 DEVSSimulation >> coordinator [
 

--- a/source/DEVS-Models-Tests/DEVSNetworkTest.class.st
+++ b/source/DEVS-Models-Tests/DEVSNetworkTest.class.st
@@ -42,7 +42,7 @@ DEVSNetworkTest >> testRoundtrip [
 	simulation := self simulation: self echoNetwork.
 	(simulation / #host1 / #server1)
 		send: #foo to: '10.0.0.2' port: 7001;
-		block: [ :message :server |
+		onIncomingDo: [ :message :server |
 			received := true.
 			payload := message payload.
 			nil ].

--- a/source/DEVS-Models-Tests/DEVSNetworkTest.class.st
+++ b/source/DEVS-Models-Tests/DEVSNetworkTest.class.st
@@ -1,0 +1,53 @@
+Class {
+	#name : 'DEVSNetworkTest',
+	#superclass : 'TestCase',
+	#category : 'DEVS-Models-Tests',
+	#package : 'DEVS-Models-Tests'
+}
+
+{ #category : 'as yet unclassified' }
+DEVSNetworkTest >> echoNetwork [ 
+	| network  |
+	network := DEVSNetwork new name: 'network'.
+
+	network addHost: ((DEVSNetworkHost new 
+		name: 'host1';
+		address: '10.0.0.1')
+			addServer: (DEVSPluggableServer new 
+		name: 'server1';
+		port: 7001);
+			yourself).
+
+	network addHost: ((DEVSNetworkHost new 
+		name: 'host2';
+		address: '10.0.0.2')
+			addServer: (DEVSEchoServer new 
+				name: 'server2';
+				port: 7001);
+			yourself).
+	^ network 
+
+]
+
+{ #category : 'as yet unclassified' }
+DEVSNetworkTest >> simulation: model [ 
+	^ DEVSSimulation new 
+		model: model;
+		coordinator: DEVSRootSolver new
+]
+
+{ #category : 'tests' }
+DEVSNetworkTest >> testRoundtrip [ 
+	| simulation received payload |
+	simulation := self simulation: self echoNetwork.
+	(simulation / #host1 / #server1)
+		send: #foo to: '10.0.0.2' port: 7001;
+		block: [ :message :server |
+			received := true.
+			payload := message payload.
+			nil ].
+	simulation
+		runTo: 10.
+	self assert: received.
+	self assert: payload equals: #foo 
+]

--- a/source/DEVS-Models-Tests/package.st
+++ b/source/DEVS-Models-Tests/package.st
@@ -1,0 +1,1 @@
+Package { #name : 'DEVS-Models-Tests' }

--- a/source/DEVS-Models/DEVSEchoServer.class.st
+++ b/source/DEVS-Models/DEVSEchoServer.class.st
@@ -1,3 +1,6 @@
+"
+I represent echo server just to just return the message I receive. I exchange source and destination information and send it to output port.
+"
 Class {
 	#name : 'DEVSEchoServer',
 	#superclass : 'DEVSServer',

--- a/source/DEVS-Models/DEVSEchoServer.class.st
+++ b/source/DEVS-Models/DEVSEchoServer.class.st
@@ -1,0 +1,37 @@
+Class {
+	#name : 'DEVSEchoServer',
+	#superclass : 'DEVSServer',
+	#category : 'DEVS-Models-network',
+	#package : 'DEVS-Models',
+	#tag : 'network'
+}
+
+{ #category : 'modeling' }
+DEVSEchoServer >> externalTransition [ 
+	messages add: (self peekFrom: #in).
+	state := #processing
+]
+
+{ #category : 'modeling' }
+DEVSEchoServer >> internalTransition [ 
+	messages ifEmpty: [ 
+		state := #idle ]
+]
+
+{ #category : 'modeling' }
+DEVSEchoServer >> outputFunction [ 
+	| message |
+	messages ifNotEmpty: [ 
+		"an echo server is supposed to just return the message it
+		received. We just exchange source and destination information
+		and send it back"
+		message := messages removeFirst.
+		self 
+			poke: (DEVSNetworkMessage new 
+				destinationAddress: message sourceAddress;
+				sourceAddress: message destinationAddress;
+				destinationPort: message sourcePort;
+				sourcePort: message destinationPort;
+				payload: message payload)
+			to: #out  ]
+]

--- a/source/DEVS-Models/DEVSHostServiceResolver.class.st
+++ b/source/DEVS-Models/DEVSHostServiceResolver.class.st
@@ -13,7 +13,7 @@ Class {
 	#tag : 'network'
 }
 
-{ #category : 'as yet unclassified' }
+{ #category : 'adding' }
 DEVSHostServiceResolver >> addServer: aServer [ 
 	ports 
 		at: aServer port 
@@ -30,7 +30,7 @@ DEVSHostServiceResolver >> address: aString [
 	address := aString 
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'modeling' }
 DEVSHostServiceResolver >> externalTransition [
 
 	| msg |
@@ -58,7 +58,7 @@ DEVSHostServiceResolver >> initialize [
 	messages := OrderedCollection new
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'modeling' }
 DEVSHostServiceResolver >> internalTransition [
 	messages ifEmpty: [  
 		state := #idle ]
@@ -74,7 +74,7 @@ DEVSHostServiceResolver >> outputFunction [
 			to: (ports at: message destinationPort) name ]
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'modeling' }
 DEVSHostServiceResolver >> timeAdvance [
 	^ (state = #processing)
 		ifTrue: [ 1 ]

--- a/source/DEVS-Models/DEVSHostServiceResolver.class.st
+++ b/source/DEVS-Models/DEVSHostServiceResolver.class.st
@@ -66,12 +66,11 @@ DEVSHostServiceResolver >> internalTransition [
 
 { #category : 'modeling' }
 DEVSHostServiceResolver >> outputFunction [
+
 	| message |
-	(state = #processing) ifTrue: [ 
-		message := messages removeFirst.
-		self 
-			poke: message 
-			to: (ports at: message destinationPort) name ]
+	state = #processing ifFalse: [ ^ self ].
+	message := messages removeFirst.
+	self poke: message to: (ports at: message destinationPort) name
 ]
 
 { #category : 'modeling' }

--- a/source/DEVS-Models/DEVSHostServiceResolver.class.st
+++ b/source/DEVS-Models/DEVSHostServiceResolver.class.st
@@ -1,3 +1,6 @@
+"
+I resolve incoming message from host and pass them to output port of desired server, based on destination network port.
+"
 Class {
 	#name : 'DEVSHostServiceResolver',
 	#superclass : 'DEVSAtomicComponent',

--- a/source/DEVS-Models/DEVSNetwork.class.st
+++ b/source/DEVS-Models/DEVSNetwork.class.st
@@ -1,3 +1,6 @@
+"
+A network that is represented by router and hosts. I wire together router with my hosts.
+"
 Class {
 	#name : 'DEVSNetwork',
 	#superclass : 'DEVSCoupledComponent',

--- a/source/DEVS-Models/DEVSNetwork.class.st
+++ b/source/DEVS-Models/DEVSNetwork.class.st
@@ -1,6 +1,9 @@
 Class {
 	#name : 'DEVSNetwork',
 	#superclass : 'DEVSCoupledComponent',
+	#instVars : [
+		'router'
+	],
 	#category : 'DEVS-Models-network',
 	#package : 'DEVS-Models',
 	#tag : 'network'
@@ -19,23 +22,22 @@ DEVSNetwork class >> example [
 ]
 
 { #category : 'modeling' }
+DEVSNetwork >> addHost: host [ 
+	
+	"add as model for DEVS"
+	self addComponent: host.
+	
+	router addHost: host.
+	
+	self addCouplings: { 
+		{ host name . #out } -> { router name . #in}.
+		{ router name . host address } -> { host name . #in } }
+]
+
+{ #category : 'modeling' }
 DEVSNetwork >> initialize [ 
-	| serverName router host |
 	super initialize.
 	
 	router := DEVSNetworkRouter new name: #router.
 	self addComponent: router.
-	1 to: 3 do: [ :n |
-		serverName := ('server', n asString).
-		host := DEVSNetworkHost new
-			name:  ('host:10.0.0.', n asString);
-			hostname: 'server', n asString, '.local';
-			address: ('10.0.0.', n asString).
-		self addComponent: host.
-		router addHost: host.
-		
-		self addCouplings: { 
-			{ host name . #out } -> { router name . #in}.
-			{ router name . host address } -> { host name . #in } }.
-		]
 ]

--- a/source/DEVS-Models/DEVSNetworkHost.class.st
+++ b/source/DEVS-Models/DEVSNetworkHost.class.st
@@ -1,3 +1,6 @@
+"
+I represent network host. I pass messages from input port to host resolver. I wire together resolver output ports (identified by IP address) with my servers.
+"
 Class {
 	#name : 'DEVSNetworkHost',
 	#superclass : 'DEVSCoupledComponent',

--- a/source/DEVS-Models/DEVSNetworkHost.class.st
+++ b/source/DEVS-Models/DEVSNetworkHost.class.st
@@ -2,13 +2,25 @@ Class {
 	#name : 'DEVSNetworkHost',
 	#superclass : 'DEVSCoupledComponent',
 	#instVars : [
-		'hostname',
-		'address'
+		'address',
+		'resolver'
 	],
 	#category : 'DEVS-Models-network',
 	#package : 'DEVS-Models',
 	#tag : 'network'
 }
+
+{ #category : 'adding' }
+DEVSNetworkHost >> addServer: server [ 
+		self addComponent: server.
+		
+		resolver addServer: server.
+		
+		self addCouplings: { 
+			{ server name . #out } -> { #self . #out }.
+			{ #self . #in } -> { resolver name . #in }.
+			{ resolver name . server port } -> { server name . #in } }
+]
 
 { #category : 'accessing' }
 DEVSNetworkHost >> address [
@@ -20,34 +32,13 @@ DEVSNetworkHost >> address: aString [
 	address := aString 
 ]
 
-{ #category : 'accessing' }
-DEVSNetworkHost >> hostname [
-	^ hostname
-]
-
-{ #category : 'initialization' }
-DEVSNetworkHost >> hostname: aString [ 
-	hostname := aString
-]
-
 { #category : 'modeling' }
 DEVSNetworkHost >> initialize [
-	| resolver server |
 	super initialize.
+	
 	self addInputPortNamed: #in.
 	self addOutputPortNamed: #out.
 			
 	resolver := DEVSHostServiceResolver new name: #resolver.
-	self addComponent: resolver.
-	7001 to: 7003 do: [ :n |
-		server := DEVSServer new
-			name:  ('port:', n asString);
-			port: n .
-		self addComponent: server.
-		resolver addServer: server.
-		self addCouplings: { 
-			{ server name . #out } -> { #self . #out }.
-			{ #self . #in } -> { resolver name . #in }.
-			{ resolver name . server port } -> { server name . #in } }.
-		]
+	self addComponent: resolver
 ]

--- a/source/DEVS-Models/DEVSNetworkMessage.class.st
+++ b/source/DEVS-Models/DEVSNetworkMessage.class.st
@@ -1,3 +1,6 @@
+"
+A simple message being sent over the network (for purpose of simulation). I keep source/destination IP address, source/destination port and payload that is consumed by destination server.
+"
 Class {
 	#name : 'DEVSNetworkMessage',
 	#superclass : 'Object',

--- a/source/DEVS-Models/DEVSNetworkMessage.class.st
+++ b/source/DEVS-Models/DEVSNetworkMessage.class.st
@@ -4,9 +4,9 @@ Class {
 	#instVars : [
 		'payload',
 		'sourceAddress',
-		'sourePort',
 		'destinationAddress',
-		'destinationPort'
+		'destinationPort',
+		'sourcePort'
 	],
 	#category : 'DEVS-Models-network',
 	#package : 'DEVS-Models',
@@ -52,10 +52,14 @@ DEVSNetworkMessage >> payload: anObject [
 { #category : 'printing' }
 DEVSNetworkMessage >> printOn: aStream [ 
 	aStream 
-		<< 'message '.
-	sourceAddress printOn: aStream.
-	aStream << ' -> '.
-	destinationAddress printOn: aStream.
+		<< 'message '
+		<< sourceAddress asString 
+		<< ':'
+		<< sourcePort asString 
+		<< ' -> '
+		<< destinationAddress asString
+		<< ':'
+		<< destinationPort asString.
 	aStream << ', payload: '.
 	payload printOn: aStream 
 ]
@@ -72,14 +76,14 @@ DEVSNetworkMessage >> sourceAddress: anObject [
 	sourceAddress := anObject
 ]
 
-{ #category : 'accessing' }
-DEVSNetworkMessage >> sourePort [
+{ #category : 'as yet unclassified' }
+DEVSNetworkMessage >> sourcePort [
 
-	^ sourePort
+	^ sourcePort 
 ]
 
 { #category : 'accessing' }
-DEVSNetworkMessage >> sourePort: anObject [
+DEVSNetworkMessage >> sourcePort: anObject [
 
-	sourePort := anObject
+	sourcePort := anObject
 ]

--- a/source/DEVS-Models/DEVSNetworkMessage.class.st
+++ b/source/DEVS-Models/DEVSNetworkMessage.class.st
@@ -76,7 +76,7 @@ DEVSNetworkMessage >> sourceAddress: anObject [
 	sourceAddress := anObject
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'accessing' }
 DEVSNetworkMessage >> sourcePort [
 
 	^ sourcePort 

--- a/source/DEVS-Models/DEVSNetworkRouter.class.st
+++ b/source/DEVS-Models/DEVSNetworkRouter.class.st
@@ -4,7 +4,6 @@ Class {
 	#instVars : [
 		'state',
 		'messages',
-		'dns',
 		'hostMapping'
 	],
 	#category : 'DEVS-Models-network',
@@ -14,9 +13,6 @@ Class {
 
 { #category : 'adding' }
 DEVSNetworkRouter >> addHost: host [
-	dns 
-		at: host hostname 
-		put: host address.
 	hostMapping 
 		at: host address 
 		put: (self addOutputPortNamed: host address ).
@@ -35,16 +31,18 @@ DEVSNetworkRouter >> externalTransition [
 { #category : 'modeling' }
 DEVSNetworkRouter >> initialize [ 
 	super initialize.
+	
 	self addInputPortNamed: #in.
 	self addOutputPortNamed: #out.
+	
 	state := #idle.
 	messages := OrderedCollection new.
-	dns := Dictionary new.
 	hostMapping := Dictionary new
 ]
 
 { #category : 'modeling' }
 DEVSNetworkRouter >> internalTransition [
+
 	messages ifEmpty: [  
 		state := #idle ]
 ]
@@ -52,6 +50,7 @@ DEVSNetworkRouter >> internalTransition [
 { #category : 'modeling' }
 DEVSNetworkRouter >> outputFunction [
 	| msg |
+	
 	(state = #processing) ifTrue: [ 
 		msg := messages removeFirst.
 		self poke: msg to: (hostMapping at: msg destinationAddress) name ].
@@ -59,6 +58,7 @@ DEVSNetworkRouter >> outputFunction [
 
 { #category : 'modeling' }
 DEVSNetworkRouter >> timeAdvance [
+
  	^ (state = #processing)
 		ifTrue: [ 1 ]
 		ifFalse: [ self infinityTime ]

--- a/source/DEVS-Models/DEVSNetworkRouter.class.st
+++ b/source/DEVS-Models/DEVSNetworkRouter.class.st
@@ -1,3 +1,6 @@
+"
+I route incoming messages from hosts (its servers) to other hosts that is identified by IP address. 
+"
 Class {
 	#name : 'DEVSNetworkRouter',
 	#superclass : 'DEVSAtomicComponent',

--- a/source/DEVS-Models/DEVSNetworkRouter.class.st
+++ b/source/DEVS-Models/DEVSNetworkRouter.class.st
@@ -49,11 +49,11 @@ DEVSNetworkRouter >> internalTransition [
 
 { #category : 'modeling' }
 DEVSNetworkRouter >> outputFunction [
+
 	| msg |
-	
-	(state = #processing) ifTrue: [ 
-		msg := messages removeFirst.
-		self poke: msg to: (hostMapping at: msg destinationAddress) name ].
+	state = #processing ifFalse: [ ^ self ].
+	msg := messages removeFirst.
+	self poke: msg to: (hostMapping at: msg destinationAddress) name
 ]
 
 { #category : 'modeling' }

--- a/source/DEVS-Models/DEVSPluggableServer.class.st
+++ b/source/DEVS-Models/DEVSPluggableServer.class.st
@@ -12,11 +12,6 @@ Class {
 	#tag : 'network'
 }
 
-{ #category : 'accessing' }
-DEVSPluggableServer >> block: aBlock [ 
-	block := aBlock
-]
-
 { #category : 'modeling' }
 DEVSPluggableServer >> externalTransition [ 
 	messages add: (self peekFrom: #in).
@@ -27,6 +22,12 @@ DEVSPluggableServer >> externalTransition [
 DEVSPluggableServer >> internalTransition [ 
 	messages ifEmpty: [ 
 		state := #idle ]
+]
+
+{ #category : 'accessing' }
+DEVSPluggableServer >> onIncomingDo: aBlock [ 
+	"aBlock that is executed when incoming message is for me"
+	block := aBlock
 ]
 
 { #category : 'modeling' }

--- a/source/DEVS-Models/DEVSPluggableServer.class.st
+++ b/source/DEVS-Models/DEVSPluggableServer.class.st
@@ -1,3 +1,6 @@
+"
+I represent application server that can consume incoming messages. I have a hook method - a block that is defined outside of me that I can execute during generating output when incoming message is for me. 
+"
 Class {
 	#name : 'DEVSPluggableServer',
 	#superclass : 'DEVSServer',

--- a/source/DEVS-Models/DEVSPluggableServer.class.st
+++ b/source/DEVS-Models/DEVSPluggableServer.class.st
@@ -1,0 +1,47 @@
+Class {
+	#name : 'DEVSPluggableServer',
+	#superclass : 'DEVSServer',
+	#instVars : [
+		'block'
+	],
+	#category : 'DEVS-Models-network',
+	#package : 'DEVS-Models',
+	#tag : 'network'
+}
+
+{ #category : 'accessing' }
+DEVSPluggableServer >> block: aBlock [ 
+	block := aBlock
+]
+
+{ #category : 'modeling' }
+DEVSPluggableServer >> externalTransition [ 
+	messages add: (self peekFrom: #in).
+	state := #processing
+]
+
+{ #category : 'modeling' }
+DEVSPluggableServer >> internalTransition [ 
+	messages ifEmpty: [ 
+		state := #idle ]
+]
+
+{ #category : 'modeling' }
+DEVSPluggableServer >> outputFunction [ 
+	| message |
+	messages ifNotEmpty: [
+		message := messages removeFirst. 
+		(self isIncoming: message)
+			ifTrue: [ 
+				(block 
+					cull: message 
+					cull: self)
+					ifNotNil: [ :reply | 
+						self 
+							poke: reply
+							to: #out  ] ]
+			ifFalse: [ 
+				self 
+					poke: message
+					to: #out ] ]
+]

--- a/source/DEVS-Models/DEVSServer.class.st
+++ b/source/DEVS-Models/DEVSServer.class.st
@@ -38,6 +38,15 @@ DEVSServer >> port: anInteger [
 	port := anInteger
 ]
 
+{ #category : 'printing' }
+DEVSServer >> printOn: aStream [
+	
+	aStream << '<'.
+	self printPathOn: aStream.
+	self port ifNotNil: [:aPort | aStream << ':'; << aPort asString ].
+	aStream << '>'
+]
+
 { #category : 'actions' }
 DEVSServer >> send: payload to: destinationAddress port: destinationPort [ 
 	self sendMessage: (DEVSNetworkMessage new 

--- a/source/DEVS-Models/DEVSServer.class.st
+++ b/source/DEVS-Models/DEVSServer.class.st
@@ -12,32 +12,20 @@ Class {
 }
 
 { #category : 'modeling' }
-DEVSServer >> externalTransition [ 
-	"this does nothing for now"
-]
-
-{ #category : 'modeling' }
 DEVSServer >> initialize [ 
 	super initialize.
+	
 	self addInputPortNamed: #in.
 	self addOutputPortNamed: #out.
+	
 	state := #idle.
 	messages := OrderedCollection new.
 	
 ]
 
-{ #category : 'modeling' }
-DEVSServer >> internalTransition [
-	
-]
-
-{ #category : 'modeling' }
-DEVSServer >> outputFunction [
-	messages ifNotEmpty: [  
-		self 
-			poke: messages removeFirst 
-			to: #out ].
-
+{ #category : 'testing' }
+DEVSServer >> isIncoming: message [
+	^ message destinationAddress = parent address
 ]
 
 { #category : 'accessing' }
@@ -48,6 +36,16 @@ DEVSServer >> port [
 { #category : 'accessing' }
 DEVSServer >> port: anInteger [ 
 	port := anInteger
+]
+
+{ #category : 'as yet unclassified' }
+DEVSServer >> send: payload to: destinationAddress port: destinationPort [ 
+	self sendMessage: (DEVSNetworkMessage new 
+			destinationAddress: destinationAddress;
+			destinationPort: destinationPort;
+			sourceAddress: parent address;
+			sourcePort: port;
+			payload: payload)
 ]
 
 { #category : 'actions' }

--- a/source/DEVS-Models/DEVSServer.class.st
+++ b/source/DEVS-Models/DEVSServer.class.st
@@ -38,7 +38,7 @@ DEVSServer >> port: anInteger [
 	port := anInteger
 ]
 
-{ #category : 'as yet unclassified' }
+{ #category : 'actions' }
 DEVSServer >> send: payload to: destinationAddress port: destinationPort [ 
 	self sendMessage: (DEVSNetworkMessage new 
 			destinationAddress: destinationAddress;

--- a/source/DEVS-Models/DEVSServer.class.st
+++ b/source/DEVS-Models/DEVSServer.class.st
@@ -1,3 +1,6 @@
+"
+I represent simple application server that is part of host. I can receive input messages from input port and sent messages to output port that is identified by my network port number.
+"
 Class {
 	#name : 'DEVSServer',
 	#superclass : 'DEVSAtomicComponent',


### PR DESCRIPTION
- This PR removes the static initialization of the DEVS model in the #initialize method in the network model
- combine special model methods (addHost:) with the functionality of the DEVS model to setup. The result is a better builder like pattern to construct a network
- added an implementation of a echo server that just returns what it receives
- add a pluggable server that uses a block to delegate message processing
- added a test package for the models. 
- added the first roundtrip that illustrates the desired API: setting up a model, setting up the simulation, tweak simulation, run simulation, assert

